### PR TITLE
Get block devices from lsblk instead of ls

### DIFF
--- a/smart_errors.sh
+++ b/smart_errors.sh
@@ -6,10 +6,10 @@
 
 smart="<i>SMART health:</i>\n"
 
-for dev in $(ls /dev/sd[a-z])
+for dev in $(lsblk -d | tail -n+2 | cut -d" " -f1)
 do
-	device_id=$(smartctl -i $dev | grep "Device Model" | cut -c 19-)
-	smart="${smart}<u>Drive: $device_id</u>\n$(smartctl -H $dev | tail -n +5)\n"
+	device_id=$(smartctl -i /dev/$dev | grep "Device Model" | cut -c 19-)
+	smart="${smart}<u>Drive: $device_id</u>\n$(smartctl -H /dev/$dev | tail -n +5)\n"
 done
 
 printf "$smart"


### PR DESCRIPTION
This fixes issue #1 while using lsblk instead of smartctl to list block devices, which stays within coreutils. sdaa, sdab etc. should be supported with this. This also guarantees the device is a block device, although not that it's SMART compatible, but smartctl would complain about that anyway.